### PR TITLE
Update fetchData.bash

### DIFF
--- a/fetchData.bash
+++ b/fetchData.bash
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+synapse login --rememberMe
+
 # Robjects
 echo "Fetching R objects..."
 synapse get syn21560469 --downloadLocation ./Analysis/seurat/


### PR DESCRIPTION
cache login so that you don't have to login for every synapse get request.

when running this script, I was having to login for each synapse get request. This update caches the login at the beginning of the script and the subsequent get requests do not require a login.